### PR TITLE
feat: Add: Second exception IllegalArgumentException 

### DIFF
--- a/guessing-game/src/main/java/com/codedifferently/q4/team2/exception/IllegalArgumentException.java
+++ b/guessing-game/src/main/java/com/codedifferently/q4/team2/exception/IllegalArgumentException.java
@@ -6,4 +6,9 @@ public class IllegalArgumentException extends RuntimeException {
 }
 }
 
+// Will throw IllegalArgumentException 
+//if the player selects a difficulty level that is not in the range of valid options (1, 2, or 3).
+
+// if (difficultyChoice < 1 || difficultyChoice > 3) {
+//  throw new IllegalArgumentException("Invalid difficulty level selected. Please select 1, 2, or 3."); }
 

--- a/guessing-game/src/main/java/com/codedifferently/q4/team2/exception/IllegalArgumentException.java
+++ b/guessing-game/src/main/java/com/codedifferently/q4/team2/exception/IllegalArgumentException.java
@@ -1,0 +1,9 @@
+package com.codedifferently.q4.team2.exception;
+
+public class IllegalArgumentException extends RuntimeException {
+    public IllegalArgumentException(String message) {
+        super(message);
+}
+}
+
+


### PR DESCRIPTION
We can throw IllegalArgumentException if the player selects a difficulty level that is not in the range of valid options (1, 2, or 3). Please review!